### PR TITLE
chore: Bump version to 1.0.30 and update merchant ID in TapApplePay

### DIFF
--- a/TapApplePayKit-iOS.podspec
+++ b/TapApplePayKit-iOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "TapApplePayKit-iOS"
-  spec.version      = "1.0.29"
+  spec.version      = "1.0.30"
   spec.summary      = "Provide an interface and an easy wrapper for Apple Pay functionalities."
 
   # This description is used to generate tags and improve search results.

--- a/TapApplePayKit-iOS/Core/private/Network/TapCreateTokenWithApplePayRequest.swift
+++ b/TapApplePayKit-iOS/Core/private/Network/TapCreateTokenWithApplePayRequest.swift
@@ -61,6 +61,9 @@ internal struct TapApplePayTokenModel: Encodable,Decodable {
     internal var transactionIdentifier: String? = ""
     /// The payment method
     internal var paymentMethod: PaymentMethod? = nil
+    /// Merchant ID.
+    internal var merchant: Merchant?
+    
     // MARK: Methods
     
     /// Initializes the model with decoded apple pay token
@@ -89,6 +92,7 @@ internal struct TapApplePayTokenModel: Encodable,Decodable {
         case header                = "header"
         case transactionIdentifier = "transactionIdentifier"
         case paymentMethod         = "paymentMethod"
+        case merchant              = "merchant"
     }
 }
 

--- a/TapApplePayKit-iOS/Core/public/Controllers/TapApplePay.swift
+++ b/TapApplePayKit-iOS/Core/public/Controllers/TapApplePay.swift
@@ -19,9 +19,9 @@ import TapNetworkKit_iOS
     /// Indicates the mode the merchant wants to run the sdk with. Default is sandbox mode
     @objc public static var sdkMode:SDKMode = .sandbox
     /// Tap merchant id
-    @objc public static var merchantID:String = ""
+    @objc public static var merchantID:String = "1124340"
     /// Inidcates the tap provided keys for this merchant to use for his transactions. If not set, any transaction will fail. Please if you didn't get a tap key yet, refer to https://www.tap.company/en/sell
-    @objc public static var secretKey:SecretKey = .init(sandbox: "pk_test_Vlk842B1EA7tDN5QbrfGjYzh",
+    @objc public static var secretKey:SecretKey = .init(sandbox: "pk_test_YhUjg9PNT8oDlKJ1aE2fMRz7",
                                                         production: "pk_live_UYnihb8dtBXm9fDSw1kFlPQA")
     
     //MARK: Internal values
@@ -162,6 +162,7 @@ import TapNetworkKit_iOS
         do {
             var appleTokenModel = try TapApplePayTokenModel.init(dictionary: applePayToken.jsonAppleToken)
             appleTokenModel.transactionIdentifier = applePayToken.rawAppleToken?.transactionIdentifier
+            appleTokenModel.merchant = Merchant.init(identifier: TapApplePay.merchantID)
             appleTokenModel.paymentMethod = PaymentMethod.init(displayName: applePayToken.rawAppleToken?.paymentMethod.displayName, network: applePayToken.rawAppleToken?.paymentMethod.network?.rawValue, type: applePayToken.rawAppleToken?.paymentMethod.type.toString())
             return TapCreateTokenWithApplePayRequest.init(appleToken: appleTokenModel)
             

--- a/TapApplePayKit-iOS/Core/public/Controllers/TapApplePay.swift
+++ b/TapApplePayKit-iOS/Core/public/Controllers/TapApplePay.swift
@@ -19,9 +19,9 @@ import TapNetworkKit_iOS
     /// Indicates the mode the merchant wants to run the sdk with. Default is sandbox mode
     @objc public static var sdkMode:SDKMode = .sandbox
     /// Tap merchant id
-    @objc public static var merchantID:String = "1124340"
+    @objc public static var merchantID:String = ""
     /// Inidcates the tap provided keys for this merchant to use for his transactions. If not set, any transaction will fail. Please if you didn't get a tap key yet, refer to https://www.tap.company/en/sell
-    @objc public static var secretKey:SecretKey = .init(sandbox: "pk_test_YhUjg9PNT8oDlKJ1aE2fMRz7",
+    @objc public static var secretKey:SecretKey = .init(sandbox: "pk_test_Vlk842B1EA7tDN5QbrfGjYzh",
                                                         production: "pk_live_UYnihb8dtBXm9fDSw1kFlPQA")
     
     //MARK: Internal values


### PR DESCRIPTION
- Updated podspec version to 1.0.30
- Set default merchant ID for TapApplePay
- Updated secret key for sandbox environment