### PR TITLE
feat: Enhance Apple Pay authorization with additional callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,13 @@ To start the payment process with one line call as follows:
 ```swift
 /**
      Public interface to be used to start Apple pay athprization process without the need to include out Tap APple Pay button
-     - Parameter presenter: The UIViewcontroller you want to show the native Apple Pay sheet in
      - Parameter tapApplePayRequest: The Tap apple request wrapper that has the valid data of your transaction
      - Parameter tokenized: The block to be called once the user successfully authorize the payment
+     - Parameter onErrorOccured: The block to call whenever there's an issue showing apple pay sheet
+     - Parameter onCancelled: The block to be called when the user cancels the payment
+     - Parameter onPresented: (Optional) The block to be called once the Apple Pay sheet is presented to the user
      */
-    public func authorizePayment(in presenter:UIViewController, for tapApplePayRequest:TapApplePayRequest, tokenized:@escaping ((TapApplePayToken)->()))
+    public func authorizePayment(for tapApplePayRequest:TapApplePayRequest, tokenized:@escaping ((TapApplePayToken)->()), onErrorOccured: @escaping((TapApplePayRequestValidationError)->()), onCancelled: @escaping () -> (), onPresented: ((Bool) -> Void)? = nil)
 
 ```
 
@@ -358,9 +360,25 @@ myTapApplePayRequest.build(paymentAmount: 10, merchantID: "merchant.tap.gosell")
 
 
 // Then you can start the payment authorization process with one call whenever you. want as follows
-tapApplePay.authorizePayment(in: self, for: myTapApplePayRequest) { [weak self] (token) in
+// Basic usage (without onPresented callback):
+tapApplePay.authorizePayment(for: myTapApplePayRequest, tokenized: { [weak self] (token) in
 	print("I can do whatever i want with the result token")
-}
+}, onErrorOccured: { error in
+	print("Error occurred: \(error.TapApplePayRequestValidationErrorRawValue())")
+}, onCancelled: {
+	print("Payment cancelled by user")
+})
+
+// Or with the optional onPresented callback:
+tapApplePay.authorizePayment(for: myTapApplePayRequest, tokenized: { [weak self] (token) in
+	print("I can do whatever i want with the result token")
+}, onErrorOccured: { error in
+	print("Error occurred: \(error.TapApplePayRequestValidationErrorRawValue())")
+}, onCancelled: {
+	print("Payment cancelled by user")
+}, onPresented: { [weak self] (isPresented) in
+	print("Apple Pay sheet presented: \(isPresented)")
+})
 ```
 
 

--- a/TapApplePayKit-Example/ViewController.swift
+++ b/TapApplePayKit-Example/ViewController.swift
@@ -181,7 +181,7 @@ class ViewController: UIViewController {
     }
     
     func authorisePayment() {
-        
+
         tapApplePay.authorizePayment(for: myTapApplePayRequest) { [weak self] (token) in
             self?.showTokenizedData(with: token)
         } onErrorOccured: { error in
@@ -192,6 +192,10 @@ class ViewController: UIViewController {
             let alertControl = UIAlertController(title: "Cancelled", message: "Cancelled", preferredStyle: .alert)
             alertControl.addAction(.init(title: "OK", style: .cancel))
             self.present(alertControl, animated: true)
+        } onPresented: { [weak self] isPresented in
+            print("Apple Pay sheet presented: \(isPresented)")
+            // You can add custom logic here when the Apple Pay sheet is presented
+            // For example, show/hide loading indicators, update UI state, etc.
         }
     }
     

--- a/TapApplePayKit-iOS.podspec
+++ b/TapApplePayKit-iOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "TapApplePayKit-iOS"
-  spec.version      = "1.0.30"
+  spec.version      = "1.0.31"
   spec.summary      = "Provide an interface and an easy wrapper for Apple Pay functionalities."
 
   # This description is used to generate tags and improve search results.

--- a/TapApplePayKit-iOS/Core/public/Controllers/TapApplePay.swift
+++ b/TapApplePayKit-iOS/Core/public/Controllers/TapApplePay.swift
@@ -32,7 +32,10 @@ import TapNetworkKit_iOS
     
     /// The apple pay cancel block. it will called when the sheet dismissed
     internal var cancelBlock: (() -> Void)?
-    
+
+    /// The block to be called once the Apple Pay sheet is presented to the user
+    internal var presentedBlock: ((Bool) -> Void)?
+
     /// The latest checkout profile api response
     public static var intitModelResponse: TapInitResponseModel?
     
@@ -75,32 +78,35 @@ import TapNetworkKit_iOS
     
     /**
      Public interface to be used to start Apple pay athprization process without the need to include out Tap APple Pay button
-     - Parameter presenter: The UIViewcontroller you want to show the native Apple Pay sheet in
      - Parameter tapApplePayRequest: The Tap apple request wrapper that has the valid data of your transaction
      - Parameter tokenized: The block to be called once the user successfully authorize the payment
      - Parameter onErrorOccured: The block to call whenever there's an issue showing apple pay sheet
+     - Parameter onCancelled: The block to be called when the user cancels the payment
+     - Parameter onPresented: The block to be called once the Apple Pay sheet is presented to the user (optional)
      */
-    @objc public func authorizePayment(for tapApplePayRequest:TapApplePayRequest, tokenized:@escaping ((TapApplePayToken)->()), onErrorOccured: @escaping((TapApplePayRequestValidationError)->()), onCancelled: @escaping () -> ()) {
-        
+    @objc public func authorizePayment(for tapApplePayRequest:TapApplePayRequest, tokenized:@escaping ((TapApplePayToken)->()), onErrorOccured: @escaping((TapApplePayRequestValidationError)->()), onCancelled: @escaping () -> (), onPresented: ((Bool) -> Void)? = nil) {
+
         // let us make sure the passed data are valid and allowed as merchant configuration
         guard validate(tapApplePayRequest: tapApplePayRequest) == .Valid else {
             onErrorOccured(validate(tapApplePayRequest: tapApplePayRequest))
             return
         }
-        
+
         // Now we are ok to start, let us do it
-        
+
         self.tokenizedBlock = tokenized
         self.cancelBlock = onCancelled
+        self.presentedBlock = onPresented
         tapApplePayRequest.updateValues()
-        
+
         let paymentController = PKPaymentAuthorizationController.init(paymentRequest: tapApplePayRequest.appleRequest)
         paymentController.delegate = self//presenter as? PKPaymentAuthorizationControllerDelegate
-        paymentController.present { (done) in
+        paymentController.present { [weak self] (done) in
             //FlurryLogger.logEvent(with: "Apple_Pay_Sheet_Presented")
             print("PRESENTED : \(done)")
+            self?.presentedBlock?(done)
         }
-        
+
     }
     
     


### PR DESCRIPTION
- Add onErrorOccured, onCancelled, and onPresented parameters to authorizePayment method
- Update example usage in ViewController to demonstrate new callbacks
- Increment podspec version to 1.0.31
